### PR TITLE
Fix config loading bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     }
     modApi "com.terraformersmc:modmenu:13.0.2"
 
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+
 }
 
 loom {
@@ -75,4 +78,8 @@ sourceSets {
         java {
         }
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/main/java/breakthemod/utils/config.java
+++ b/src/main/java/breakthemod/utils/config.java
@@ -174,6 +174,10 @@ public class config {
     public boolean isTowny() { return towny;}
     public void setTowny(boolean bl) { towny = bl;}
 
+    static boolean getBoolean(JsonObject obj, String key, boolean defaultVal) {
+        return obj.has(key) ? obj.get(key).getAsBoolean() : defaultVal;
+    }
+
     public void saveConfig() {
         JsonObject configJson = new JsonObject();
         configJson.addProperty("widgetPosition", widgetPosition.name());
@@ -199,10 +203,10 @@ public class config {
                         : WidgetPosition.TOP_LEFT;
                 customX = configJson.has("customX") ? configJson.get("customX").getAsInt() : 0;
                 customY = configJson.has("customY") ? configJson.get("customY").getAsInt() : 0;
-                radarEnabled = !configJson.has("radarEnabled") || configJson.get("radarEnabled").getAsBoolean();
-                enabledOnOtherServers = configJson.has("enabledOnOtherServers") && configJson.get("enabledOnOtherServers").getAsBoolean();
-                dev = configJson.has("dev") ? configJson.get("dev").getAsBoolean() : dev;
-                towny = configJson.has("towny") ? configJson.get("dev").getAsBoolean() : towny;
+                radarEnabled = getBoolean(configJson, "radarEnabled", true);
+                enabledOnOtherServers = getBoolean(configJson, "enabledOnOtherServers", false);
+                dev = getBoolean(configJson, "dev", dev);
+                towny = getBoolean(configJson, "towny", towny);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/test/java/breakthemod/utils/ConfigTest.java
+++ b/src/test/java/breakthemod/utils/ConfigTest.java
@@ -1,0 +1,20 @@
+package breakthemod.utils;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigTest {
+    @Test
+    public void testGetBooleanParsesTowny() {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("towny", true);
+        assertTrue(config.getBoolean(obj, "towny", false));
+    }
+
+    @Test
+    public void testGetBooleanUsesDefaultWhenMissing() {
+        JsonObject obj = new JsonObject();
+        assertFalse(config.getBoolean(obj, "towny", false));
+    }
+}


### PR DESCRIPTION
## Summary
- fix `towny` flag loading in `config`
- add a helper for boolean JSON parsing
- add JUnit tests and enable them in build

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a9862356c8321974a084a8d19b76f